### PR TITLE
Upgrade to Wicket 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<groupId>net.ftlines.wicket-source</groupId>
 	<artifactId>wicket-source-parent</artifactId>
-	<version>6.0.0.9-SNAPSHOT</version>
+	<version>7.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<description>Wicket-source displays component instantiation location in an html attribute, speeding the modification of existing wicket pages. The only module required for maven dependency in your app is wicket-source itself, although a demo app is included.</description>
 	<name>Wicket Source With Plugins</name>
@@ -38,6 +38,7 @@
 	</developers>
 
 	<properties>
+		<wicket.version>7.0.0-M1</wicket.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/wicket-source-demo/pom.xml
+++ b/wicket-source-demo/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>net.ftlines.wicket-source</groupId>
 		<artifactId>wicket-source-parent</artifactId>
-		<version>6.0.0.9-SNAPSHOT</version>
+		<version>7.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-source-demo</artifactId>
@@ -11,8 +11,7 @@
 	<name>Wicket Source Demo</name>
 	<description>Wicket Quick-Start project demonstrating use of Wicket-Source</description>
 	<properties>
-		<wicket.version>6.0.0</wicket.version>
-		<jetty.version>7.5.0.v20110901</jetty.version>
+		<jetty.version>8.1.15.v20140411</jetty.version>
 	</properties>
 	<dependencies>
 		<!-- Project we're demonstrating -->
@@ -38,19 +37,19 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<version>1.7.6</version>
 		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.16</version>
+			<version>1.2.17</version>
 		</dependency>
 
 		<!-- JUNIT DEPENDENCY FOR TESTING -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
+			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -128,10 +127,10 @@
 				<inherited>true</inherited>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 					<optimize>true</optimize>
 					<debug>true</debug>
 				</configuration>
@@ -154,6 +153,8 @@
 							<keyPassword>wicket</keyPassword>
 						</connector>
 					</connectors>
+					<stopKey>stop</stopKey>
+					<stopPort>47890</stopPort>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/wicket-source-demo/src/test/java/net/ftlines/wicketsource/demo/Start.java
+++ b/wicket-source-demo/src/test/java/net/ftlines/wicketsource/demo/Start.java
@@ -1,11 +1,11 @@
 package net.ftlines.wicketsource.demo;
 
 import org.apache.wicket.util.time.Duration;
-import org.eclipse.jetty.http.ssl.SslContextFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.bio.SocketConnector;
 import org.eclipse.jetty.server.ssl.SslSocketConnector;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 public class Start {
@@ -35,7 +35,7 @@ public class Start {
             SslContextFactory factory = new SslContextFactory();
             factory.setKeyStoreResource(keystore);
             factory.setKeyStorePassword("wicket");
-            factory.setTrustStore(keystore);
+            factory.setTrustStoreResource(keystore);
             factory.setKeyManagerPassword("wicket");
             SslSocketConnector sslConnector = new SslSocketConnector(factory);
             sslConnector.setMaxIdleTime(timeout);

--- a/wicket-source/pom.xml
+++ b/wicket-source/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>net.ftlines.wicket-source</groupId>
 		<artifactId>wicket-source-parent</artifactId>
-		<version>6.0.0.9-SNAPSHOT</version>
+		<version>7.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>wicket-source</artifactId>
@@ -18,11 +18,6 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
-
-	<properties>
-		<wicket.version>6.0.0</wicket.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Hi,

Please release a version that is built against Wicket 7.0.0-M1 once it gets released (I will notify you!).
Wicket-Source is source compatible with Wicket 7.x but there are binary API breaks like in Application#setMetaData() and thus requires a new release. 
