### PR TITLE
Use development config patch

### DIFF
--- a/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
+++ b/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
@@ -17,7 +17,7 @@ public class WicketSource {
 	 */
 	public static void configure(Application application)
 	{
-		if (usesDevelopmentConfig()) {
+		if (application.usesDevelopmentConfig()) {
 			application.getComponentInstantiationListeners().add(new AttributeModifyingInstantiationListener());
 			application.getComponentPostOnBeforeRenderListeners().add(new AttributeModifyingComponentVisitor());
 		}

--- a/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
+++ b/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
@@ -11,13 +11,16 @@ import org.apache.wicket.Application;
 public class WicketSource {
 
 	/**
-	 * Preferred entry point for configuring your WicketApplication automatically.
+	 * Preferred entry point for configuring your WicketApplication automatically. 
+	 * WicketSource configuration is only supposed to run in DEVELOPMENT configuration.
 	 * @param application Your wicket application
 	 */
 	public static void configure(Application application)
 	{
-		application.getComponentInstantiationListeners().add(new AttributeModifyingInstantiationListener());
-		application.getComponentPostOnBeforeRenderListeners().add(new AttributeModifyingComponentVisitor());
+		if (usesDevelopmentConfig()) {
+			application.getComponentInstantiationListeners().add(new AttributeModifyingInstantiationListener());
+			application.getComponentPostOnBeforeRenderListeners().add(new AttributeModifyingComponentVisitor());
+		}
 	}
 	
 }


### PR DESCRIPTION
I suggest configure the WicketSource code only, if Wicket is used in develolpment configuration. Otherwise internals like class names and line numbers are exposed to users, which may be a security issue. 
